### PR TITLE
Links naar testbestanden gewijzigd

### DIFF
--- a/src/installeren-en-starten.md
+++ b/src/installeren-en-starten.md
@@ -101,5 +101,5 @@ En op Windows (zonder `.\` in Command Prompt):
 
 ## Testdocumenten
 
-In de map [pvs-juinen](./testdocumenten/test-pvs-juinen/) staan de processen-verbaal voor de testgemeente Juinen, waarmee je de testverkiezing kunt invoeren.
-Daarnaast staan in de map [emls-juinen](./testdocumenten/test-emls-juinen/) de eml-bestanden waarmee je deze testverkiezing zelf kunt toevoegen.
+In de map [test-pvs-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/src/testdocumenten/test-pvs-juinen) op GitHub staan de processen-verbaal voor de testgemeente Juinen, waarmee je de testverkiezing kunt invoeren.
+Daarnaast staan in de map [test-emls-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/src/testdocumenten/test-emls-juinen) de EML-bestanden waarmee je deze testverkiezing zelf kunt toevoegen.


### PR DESCRIPTION
De links naar de testbestanden werden niet meegenomen door mdbook, dus ze zijn vervangen door externe links.