### PR TITLE
Update Hashcodes-Juinen.txt

### DIFF
--- a/src/testdocumenten/test-emls-juinen/Hashcodes-Juinen.txt
+++ b/src/testdocumenten/test-emls-juinen/Hashcodes-Juinen.txt
@@ -2,7 +2,4 @@
 fae2 12ff 03ce 27d0 45e2 15ee a0c1 7e0e 316e 331f 2641 50a3 feef 2ac3 61db 2528
 
 eml_hash eml230b_kandidatenlijsten-juinen.eml.xml
-a0f4 c7fb 1229 d7ec e1a2 43cc f460 036f 1a4a 71bc 1126 827e ad88 7eaf 7979 2d65 
-
-eml_hash eml110b_stembureaulijst-juinen.eml.xml
-4f5b 22ad 9383 1b14 357a b167 47db 91e4 e01d fce7 8a4c 9faf 983c 75ed f5ec e165
+dbc0 cdb7 08f3 1ca3 17f9 802d 6610 49b0 609c 0b8e 154c 85ba c7ad b216 2875 e778


### PR DESCRIPTION
John found an error in the hash for the kandidatenlijst - many thanks! This PR replaces the hash with the correct one and removes the hash for the stembureau EML as it is not used.