### PR TITLE
Installatie Windows: Info over command prompt bij starten

### DIFF
--- a/src/installatie/installeren-starten/windows.md
+++ b/src/installatie/installeren-starten/windows.md
@@ -33,4 +33,4 @@ Bij deze installatiemethode worden drie snelkoppelingen op het bureaublad geplaa
 
 ![Snelkoppelingen op het bureaublad](./img/windows-snelkoppelingen.png)
 
-**Let op:** Wanneer je de Abacus-server start, start Windows een command prompt. Zorg ervoor dat dit venster moet open blijft. Als je het venster sluit wordt de Abacus-server gestopt.
+**Let op:** Wanneer je de Abacus-server start, start Windows een command prompt. Zorg ervoor dat dit venster open blijft. Als je dit venster sluit wordt de Abacus-server gestopt.


### PR DESCRIPTION
- Extra info toegevoegd: command prompt wordt geopend wannneer Abacus wordt gestart en dit venster moet open blijven
- Koppen toegevoegd voor de duidelijkheid