### PR TITLE
fixes links to test files folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ De brondocumenten van de gebruikersdocumentatie zijn te vinden in deze repositor
 
 In deze repository staan verschillende testdocumenten:
 
-- In de map [pvs-juinen](https://github.com/kiesraad/abacus-documentatie/tree/src/main/testdocumenten/test-pvs-juinen/) staan de processen-verbaal voor de testgemeente Juinen, waarmee je de testverkiezing kunt invoeren.
-- Daarnaast staan in de map [emls-juinen](https://github.com/kiesraad/abacus-documentatie/tree/src/main/testdocumenten/test-emls-juinen/) de eml-bestanden waarmee je deze testverkiezing zelf kunt toevoegen.
+- In de map [test-pvs-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/gebruikersdocumentatie/src/testdocumenten/test-pvs-juinen) staan de processen-verbaal voor de testgemeente Juinen, waarmee je de testverkiezing kunt invoeren.
+- Daarnaast staan in de map [test-emls-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/gebruikersdocumentatie/src/testdocumenten/test-emls-juinen) de eml-bestanden waarmee je deze testverkiezing zelf kunt toevoegen.
 
 ## Externe documentatie
 

--- a/gebruikersdocumentatie/src/installatie/testdocumenten.md
+++ b/gebruikersdocumentatie/src/installatie/testdocumenten.md
@@ -1,5 +1,5 @@
 # Testdocumenten
 
-In de map [test-pvs-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/src/testdocumenten/test-pvs-juinen) op GitHub staan de processen-verbaal voor de testgemeente Juinen, waarmee je de testverkiezing kunt invoeren.
+In de map [test-pvs-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/gebruikersdocumentatie/src/testdocumenten/test-pvs-juinen) op GitHub staan de processen-verbaal voor de testgemeente Juinen, waarmee je de testverkiezing kunt invoeren.
 
-Daarnaast staan in de map [test-emls-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/src/testdocumenten/test-emls-juinen) de EML-bestanden waarmee je deze testverkiezing zelf kunt toevoegen.
+Daarnaast staan in de map [test-emls-juinen](https://github.com/kiesraad/abacus-documentatie/tree/main/gebruikersdocumentatie/src/testdocumenten/test-emls-juinen) de EML-bestanden waarmee je deze testverkiezing zelf kunt toevoegen.


### PR DESCRIPTION
In PR #38 "move abacus usecases etc to this repo" the location of the test file folders (PVs and EMLs Juinen) was changed, but the links to those folders was not updated. This PR fixes those links.