### PR TITLE
clarify that number of votes should exceed preference threshold

### DIFF
--- a/verkiezingsproces/zetelverdeling-GR.md
+++ b/verkiezingsproces/zetelverdeling-GR.md
@@ -89,7 +89,7 @@ Overleden kandidaten worden buiten beschouwing gelaten. (art P19a)
 - Stel voorkeursdrempel vast
   - \>= 19 raadszetels: 25% van kiesdeler
   - < 19 raadszetels: 50% van kiesdeler
-- Selecteer kandidaten die voorkeursdrempel gehaald hebben
+- Selecteer kandidaten wiens aantal stemmen groter is dan de voorkeursdrempel
 - Ken zetels toe op volgorde van aantal behaalde stemmen (tot aantal behaalde zetels van de lijst)
 - Bij gelijke aantallen stemmen, maar minder zetels: loting in zitting CSB
 


### PR DESCRIPTION
Een kandidaat moet meer stemmen hebben dan de voorkeursdrempel, niet: meer of gelijk aan. Onze beschrijving van de zetelverdeling heeft het over het halen van die drempel, dus: meer of gelijk aan. Dit PR corrigeert dat.

Gevolg is dat onze implementatie ook meer of gelijk aan doet. Hiervoor heb ik issue https://github.com/kiesraad/abacus/issues/3208 voor aangemaakt in de epic "Resolve apportionment differences OSV and Abacus".