### PR TITLE
Correctie op CSB bestanden tabel

### DIFF
--- a/use-cases/input-en-output/input-output-bestanden.md
+++ b/use-cases/input-en-output/input-output-bestanden.md
@@ -150,10 +150,6 @@ EML_NL 510a (tellingsbestand stembureau) wordt niet gebruikt.
 
 | Model(onderdeel)   | DSO | CSO | Doel                                        | input voor Abacus | output van Abacus |
 |--------------------|:---:|:---:|---------------------------------------------|:-----------------:|:-----------------:|
-| Na 31-1            |  X  |     | PV GSB - 1ste zitting                       |         X         |                   |
-| Na 31-2            |     |  X  | PV GSB - 1ste zitting                       |         X         |                   |
-| Na 14-2            |  X  |  X  | Corrigendum GSB - 2de zitting               |         X         |                   |
-| P 2a               |  X  |  X  | Verslag 2de zitting GSB                     |                   |                   |
 | P 22-2             |  X  |  X  | PV CSB - einduitslag                        |                   |         X         |
 | P 22-2 Bijlage 1   |  X  |  X  | PV CSB - stemmen per lijst en per kandidaat |                   |         X         |
 

--- a/use-cases/input-en-output/input-output-bestanden.md
+++ b/use-cases/input-en-output/input-output-bestanden.md
@@ -150,6 +150,9 @@ EML_NL 510a (tellingsbestand stembureau) wordt niet gebruikt.
 
 | Model(onderdeel)   | DSO | CSO | Doel                                        | input voor Abacus | output van Abacus |
 |--------------------|:---:|:---:|---------------------------------------------|:-----------------:|:-----------------:|
+| Na 31-1            |  X  |     | PV GSB - 1ste zitting                       |         X         |                   |
+| Na 31-2            |     |  X  | PV GSB - 1ste zitting                       |         X         |                   |
+| Na 14-2            |  X  |  X  | Corrigendum GSB - 2de zitting               |         X         |                   |
 | P 22-2             |  X  |  X  | PV CSB - einduitslag                        |                   |         X         |
 | P 22-2 Bijlage 1   |  X  |  X  | PV CSB - stemmen per lijst en per kandidaat |                   |         X         |
 


### PR DESCRIPTION
Tabel met CSB bestanden bevat P2a bestand, maar dat is geen input of output, dus die moet uit de tabel verwijderd worden.