### PR TITLE
Hoofdstuk 9 gebruikersdocumentatie: links aangepast

### DIFF
--- a/gebruikersdocumentatie/src/verkiezingsproces/rol-abacus/README.md
+++ b/gebruikersdocumentatie/src/verkiezingsproces/rol-abacus/README.md
@@ -7,4 +7,4 @@ Het doel van Abacus is om de papieren processen-verbaal te digitaliseren en te h
 - Volledig open source ontwikkelen.
 - De oplossing zelf ontwikkelen en beheren.
 
-Abacus wordt in de eerste instantie ontwikkeld voor de gemeenteraadsverkiezingen in maart 2026. Meer informatie over de functionaliteit die wordt gebouwd vind je in [Functionaliteit voor Abacus 1.0](https://github.com/kiesraad/abacus/blob/main/documentatie/functionaliteit/versie-1.0-gr2026.md).
+Abacus wordt in de eerste instantie ontwikkeld voor de gemeenteraadsverkiezingen in maart 2026. Meer informatie over de functionaliteit die wordt gebouwd vind je in [Functionaliteit van Abacus: eisen en wensen](https://github.com/kiesraad/abacus-documentatie/blob/main/functionaliteit/functionaliteit-eisen-en-wensen.md).

--- a/gebruikersdocumentatie/src/verkiezingsproces/rol-abacus/technisch-architectuur.md
+++ b/gebruikersdocumentatie/src/verkiezingsproces/rol-abacus/technisch-architectuur.md
@@ -8,8 +8,8 @@ De backend wordt gemaakt met Rust, een high-level programmeertaal waarmee je eff
 
 Voor de database wordt SQLite gebruikt. Deze library is populair, lichtgewicht en gebruiksvriendelijk voor developers, en bovendien is SQLite een '[zero-configuration database](https://www.sqlite.org/zeroconf.html)'. Dit betekent dat installeren niet nodig is, zodat de developer meteen aan de slag kan.
 
-Voor meer informatie over onze keuzes en de onderbouwingen hiervan lees je het document [Overwegingen talen en frameworks](https://github.com/kiesraad/abacus/blob/main/documentatie/softwarearchitectuur/overwegingen-talen-en-frameworks.md).
+Voor meer informatie over onze keuzes en de onderbouwingen hiervan lees je het document [Overwegingen talen en frameworks](https://github.com/kiesraad/abacus-documentatie/blob/main/softwarearchitectuur/overwegingen-talen-en-frameworks.md).
 
-Voor de architectuur kun je beginnen bij het [Overzicht van de softwarearchitectuur](https://github.com/kiesraad/abacus/blob/main/documentatie/softwarearchitectuur/Overzicht.md).
+Voor de architectuur kun je beginnen bij het [Overzicht van de softwarearchitectuur](https://github.com/kiesraad/abacus-documentatie/blob/main/softwarearchitectuur/Overzicht.md).
 
 De UI/UX designs vind je in onze [Figma](https://www.figma.com/design/xHDfsv69Nhmk3IrWC0303B/Public---Kiesraad---Abacus-optelsoftware?node-id=3190-28385&t=VnghjibSJMqrQepm-1).

--- a/gebruikersdocumentatie/src/verkiezingsproces/rol-abacus/werkwijze.md
+++ b/gebruikersdocumentatie/src/verkiezingsproces/rol-abacus/werkwijze.md
@@ -11,7 +11,7 @@ Ons team werkt volgens deze principes:
 
 Voor meer informatie over onze werkwijzen kun je de volgende links bekijken:
 
-- De [werkwijze op GitHub](https://github.com/kiesraad/abacus/blob/main/documentatie/ontwikkelproces/GitHub-werkwijze.md)
-- Het [proces voor ontwikkeling en releases](https://github.com/kiesraad/abacus/blob/main/documentatie/ontwikkelproces/proces-ontwikkeling-en-releases.md)
-- De [methode voor refinement](https://github.com/kiesraad/abacus/blob/main/documentatie/ontwikkelproces/refinement.md)
-- De [tools](https://github.com/kiesraad/abacus/blob/main/documentatie/ontwikkelproces/test-tooling.md) die het team gebruikt voor tests en hoe we omgaan met [testen en kwaliteit](https://github.com/kiesraad/abacus/blob/main/documentatie/ontwikkelproces/testen-en-kwaliteit.md)
+- De [werkwijze op GitHub](https://github.com/kiesraad/abacus-documentatie/blob/main/ontwikkelproces/GitHub-werkwijze.md)
+- Het [proces voor ontwikkeling en releases](https://github.com/kiesraad/abacus-documentatie/blob/main/ontwikkelproces/proces-ontwikkeling-en-releases.md)
+- De [methode voor refinement](https://github.com/kiesraad/abacus-documentatie/blob/main/ontwikkelproces/refinement.md)
+- De [tools](https://github.com/kiesraad/abacus-documentatie/blob/main/ontwikkelproces/test-tooling.md) die het team gebruikt voor tests en hoe we omgaan met [testen en kwaliteit](https://github.com/kiesraad/abacus-documentatie/blob/main/ontwikkelproces/testen-en-kwaliteit.md)


### PR DESCRIPTION
- Links in hoofdstuk 9.4 De Rol van Abacus aangepast n.a.v. eerdere verhuizing van de documenten
- Link in README.md gewijzigd naar algemene link die voor alle releases relevant blijft